### PR TITLE
Handle SHT1x read failures

### DIFF
--- a/SHT1x/SHT1x.h
+++ b/SHT1x/SHT1x.h
@@ -61,6 +61,7 @@ class SHT1x
     float readTemperatureF() const;
 
   private:
+    static const uint16_t kRawDataError = 0xFFFF;
     uint16_t readRawData(ShtCommand command, uint8_t dataPin, uint8_t clockPin) const;
     bool sendCommandSHT(ShtCommand command, uint8_t dataPin, uint8_t clockPin) const;
     bool waitForResultSHT(uint8_t dataPin) const;


### PR DESCRIPTION
## Summary
- avoid undefined behavior by using a sentinel value for failed sensor reads
- propagate read failures as `NAN` from temperature and humidity APIs

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno SHT1x/examples/SHT1x_Test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab2118848327ad556fb0f1e44d79